### PR TITLE
Add mypy configuration with stricter overrides for public modules

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -128,3 +128,23 @@ addopts = [
     "--cov-fail-under=95",
     "--cov-report=term-missing",
 ]
+
+[tool.mypy]
+python_version = "3.12"
+warn_unused_ignores = true
+warn_redundant_casts = true
+warn_unreachable = true
+no_implicit_optional = true
+strict_equality = true
+pretty = true
+# Default expectations for the codebase; public modules may override to be stricter.
+disallow_incomplete_defs = false
+disallow_untyped_defs = false
+
+[[tool.mypy.overrides]]
+module = [
+  "python_ntfy.client",
+  "python_ntfy.__init__",
+]
+disallow_incomplete_defs = true
+disallow_untyped_defs = true


### PR DESCRIPTION
## Summary
Add a `[tool.mypy]` configuration to `pyproject.toml` with sensible defaults and stricter overrides for public-facing modules (`python_ntfy.client`, `python_ntfy.__init__`). This enforces annotations where it matters most, without blocking internal helpers.

## Details
- Global mypy defaults: keep untyped defs allowed for now
- Overrides: `disallow_untyped_defs = true`, `disallow_incomplete_defs = true` for public modules
- Verified via `just mypy` and `just check`

## Test plan
- Run `just mypy` — should pass
- Run `just check` — lint and format checks should pass