### PR TITLE
Update audit command in Justfile and remove uv-secure criteria from pyproject.toml

### DIFF
--- a/Justfile
+++ b/Justfile
@@ -53,7 +53,7 @@ test: lint mypy pytest
 # Audit dependencies for security vulnerabilities
 [group("Security")]
 audit:
-    uvx uv-secure uv.lock
+    uv audit --frozen --preview-features audit
 
 # Build mkdocs site
 [group("docs")]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -130,13 +130,3 @@ disallow_untyped_defs = true
 [tool.ty.environment]
 root = ["."]
 python = "./.venv"
-
-[tool.uv-secure.vulnerability_criteria]
-show_severity = true
-ignore_unfixed = true
-
-[tool.uv-secure.maintainability_criteria]
-forbid_yanked = true
-forbid_archived = true
-forbid_deprecated = true
-forbid_quarantined = true


### PR DESCRIPTION
Replaces the archived tool `uv-secure`.
